### PR TITLE
Add ctx.Offset as alias of ctx.Skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,8 +183,10 @@ available options can be found here:
 [rebecca.Context](https://godoc.org/github.com/waterlink/rebecca#Context)
 
 ```go
-kidsBatch := []Person{}
 ctx := &rebecca.Context{Order: "age ASC", Limit: 300, Skip: 300}
+// you can also use `Offset: 300`
+
+kidsBatch := []Person{}
 if err := ctx.Where(&kidsBatch, "age < $1", 12); err != nil {
         // handle error here
 }
@@ -196,8 +198,8 @@ This example uses following options:
 - `Order` - ordering of the query, maps to `ORDER BY` clause in various SQL
   dialects.
 - `Limit` - maximum amount of records to be queried, maps to `LIMIT` clause.
-- `Skip` - defines amount of records to skip, maps to `OFFSET`
-  clause.
+- `Skip` (or its alias `Offset`) - defines amount of records to skip, maps to
+  `OFFSET` clause.
 
 Don't confuse `rebecca.Context` with this interface:
 [rebecca/context](https://godoc.org/github.com/waterlink/rebecca/context). This
@@ -220,8 +222,9 @@ type PeopleByAge struct {
 Next, lets query this using the `Context`:
 
 ```go
-peopleByAge := []PeopleByAge{}
 ctx := &rebecca.Context{Group: "age"}
+
+peopleByAge := []PeopleByAge{}
 if err := ctx.All(&peopleByAge); err != nil {
         // handle error here
 }

--- a/context.go
+++ b/context.go
@@ -18,7 +18,8 @@ type Context struct {
 	Limit int
 
 	// Defines starting record for the query
-	Skip int
+	Skip   int
+	Offset int // alias of Skip
 
 	tx interface{}
 }
@@ -38,8 +39,12 @@ func (c *Context) GetLimit() int {
 	return c.Limit
 }
 
-// GetSkip is for fetching context's Skip. Used by drivers
+// GetSkip is for fetching context's Skip. Also it fetches Offset if present,
+// hence the alias. Used by drivers
 func (c *Context) GetSkip() int {
+	if c.Offset > 0 {
+		return c.Offset
+	}
 	return c.Skip
 }
 
@@ -50,46 +55,31 @@ func (c *Context) GetTx() interface{} {
 
 // SetOrder is for setting context's Order, it creates new Context. Used by drivers
 func (c *Context) SetOrder(order string) context.Context {
-	return &Context{
-		Order: order,
-		Group: c.Group,
-		Limit: c.Limit,
-		Skip:  c.Skip,
-		tx:    c.tx,
-	}
+	ctx := c.makeCopy()
+	ctx.Order = order
+	return &ctx
 }
 
 // SetGroup is for setting context's Group. Used by drivers
 func (c *Context) SetGroup(group string) context.Context {
-	return &Context{
-		Order: c.Order,
-		Group: group,
-		Limit: c.Limit,
-		Skip:  c.Skip,
-		tx:    c.tx,
-	}
+	ctx := c.makeCopy()
+	ctx.Group = group
+	return &ctx
 }
 
 // SetLimit is for setting context's Limit. Used by drivers
 func (c *Context) SetLimit(limit int) context.Context {
-	return &Context{
-		Order: c.Order,
-		Group: c.Group,
-		Limit: limit,
-		Skip:  c.Skip,
-		tx:    c.tx,
-	}
+	ctx := c.makeCopy()
+	ctx.Limit = limit
+	return &ctx
 }
 
 // SetSkip is for setting context's Skip. Used by drivers
 func (c *Context) SetSkip(skip int) context.Context {
-	return &Context{
-		Order: c.Order,
-		Group: c.Group,
-		Limit: c.Limit,
-		Skip:  skip,
-		tx:    c.tx,
-	}
+	ctx := c.makeCopy()
+	ctx.Skip = skip
+	ctx.Offset = skip
+	return &ctx
 }
 
 // All is for fetching all records
@@ -147,4 +137,8 @@ func (c *Context) First(record interface{}, query string, args ...interface{}) e
 	}
 
 	return nil
+}
+
+func (c Context) makeCopy() Context {
+	return c
 }

--- a/context_test.go
+++ b/context_test.go
@@ -21,6 +21,21 @@ func ExampleContext_All() {
 	fmt.Print(people)
 }
 
+func ExampleContext_All_skipOffsetAlias() {
+	type Person struct {
+		// ...
+	}
+
+	ctx := rebecca.Context{Limit: 20, Offset: 40}
+	people := []Person{}
+	if err := ctx.All(&people); err != nil {
+		panic(err)
+	}
+	// At this point people contains 20 Person records starting from 41th from
+	// the database.
+	fmt.Print(people)
+}
+
 func ExampleContext_First() {
 	type Person struct {
 		// ...

--- a/pgdriver/pgdriver_test.go
+++ b/pgdriver/pgdriver_test.go
@@ -237,35 +237,50 @@ func TestSkip(t *testing.T) {
 		}
 	}
 
-	ctx := &rebecca.Context{Skip: 2}
-	expected := []Person{*p3, *p4, *p5, *p6}
-	actual := []Person{}
-	if err := ctx.All(&actual); err != nil {
-		t.Fatal(err)
+	examples := map[string]struct {
+		ctx *rebecca.Context
+	}{
+		"when using Skip option it works": {
+			ctx: &rebecca.Context{Skip: 2},
+		},
+
+		"when using Offset option it should be the same": {
+			ctx: &rebecca.Context{Offset: 2},
+		},
 	}
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Expected %+v to equal %+v", actual, expected)
-	}
+	for _, e := range examples {
+		ctx := e.ctx
 
-	expected = []Person{*p5, *p6}
-	actual = []Person{}
-	if err := ctx.Where(&actual, "age > $1", 11); err != nil {
-		t.Fatal(err)
-	}
+		expected := []Person{*p3, *p4, *p5, *p6}
+		actual := []Person{}
+		if err := ctx.All(&actual); err != nil {
+			t.Fatal(err)
+		}
 
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Expected %+v to equal %+v", actual, expected)
-	}
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Expected %+v to equal %+v", actual, expected)
+		}
 
-	expectedOne := p4
-	actualOne := &Person{}
-	if err := ctx.First(&actualOne, "age > $1", 10); err != nil {
-		t.Fatal(err)
-	}
+		expected = []Person{*p5, *p6}
+		actual = []Person{}
+		if err := ctx.Where(&actual, "age > $1", 11); err != nil {
+			t.Fatal(err)
+		}
 
-	if !reflect.DeepEqual(actualOne, expectedOne) {
-		t.Errorf("Expected %+v to equal %+v", actualOne, expectedOne)
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("Expected %+v to equal %+v", actual, expected)
+		}
+
+		expectedOne := p4
+		actualOne := &Person{}
+		if err := ctx.First(&actualOne, "age > $1", 10); err != nil {
+			t.Fatal(err)
+		}
+
+		if !reflect.DeepEqual(actualOne, expectedOne) {
+			t.Errorf("Expected %+v to equal %+v", actualOne, expectedOne)
+		}
 	}
 }
 


### PR DESCRIPTION
People from different background are used to call this `offset`, other people are used to call this `skip`. So here you are - they are aliases now.
