### PR TITLE
Move auto docs deeper in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,30 +48,10 @@ And in code:
 rebecca.SetupDriver(pgdriver.NewDriver("postgres://user:pass@host:port/database?sslmode=sslmode"))
 ```
 
-The same can be done with empty import:
-
-```go
-import _ "github.com/waterlink/rebecca/pgdriver/auto"
-```
-
-Empty import will fetch connection options from respective environment
-variables:
-
-- `REBECCA_PG_USER`
-- `REBECCA_PG_PASS`
-- `REBECCA_PG_HOST`
-- `REBECCA_PG_PORT`
-- `REBECCA_PG_DATABASE`
-- `REBECCA_PG_SSLMODE`
-
-or, if present: `REBECCA_PG_URL`
-
-To find out each driver's respective environment variables, see its
-documentation.
-
 ### List of supported drivers
 
 - `github.com/waterlink/rebecca/pgdriver` - driver for postgresql.
+  [Docs](https://godoc.org/github.com/waterlink/rebecca/pgdriver)
 - TODO:
   - `github.com/waterlink/rebecca/cassdriver` - driver for cassandra.
   - `github.com/waterlink/rebecca/mysqldriver` - driver for mysql.

--- a/pgdriver/auto/auto.go
+++ b/pgdriver/auto/auto.go
@@ -1,4 +1,22 @@
-package pgdriverauto
+// Package auto allows one to setup rebecca/pgdriver in a convenient way from
+// environment variables.
+//
+// To start using auto use this nameless import:
+//
+// 				import _ "github.com/waterlink/rebecca/pgdriver/auto"
+//
+// Empty import will fetch connection options from respective environment
+// variables:
+//
+// - `REBECCA_PG_USER`
+// - `REBECCA_PG_PASS`
+// - `REBECCA_PG_HOST`
+// - `REBECCA_PG_PORT`
+// - `REBECCA_PG_DATABASE`
+// - `REBECCA_PG_SSLMODE`
+//
+// or, if present: `REBECCA_PG_URL`
+package auto
 
 import (
 	"fmt"

--- a/pgdriver/pgdriver.go
+++ b/pgdriver/pgdriver.go
@@ -1,5 +1,23 @@
 // Package pgdriver provides implementation of rebecca driver for postgres. It
 // uses github.com/lib/pq and database/sql under the hood.
+//
+// Enabling this driver for rebecca:
+//
+// First import both `rebecca` and `pgdriver` in your main.go (or in your test
+// suite):
+//
+// 				import (
+// 					"github.com/waterlink/rebecca"
+//					"github.com/waterlink/rebecca/pgdriver"
+//				)
+//
+// Then in your top level func (`main` or `TestMain`):
+//
+//				d := pgdriver.NewDriver("postgres://user:pass@host:port/database?sslmode=sslmode")
+//				rebecca.SetupDriver(d)
+//
+// The same can be done through environment variables with package
+// https://godoc.org/github.com/waterlink/rebecca/pgdriver/auto
 package pgdriver
 
 import (


### PR DESCRIPTION
So that it is easier to read the readme. And `auto` package is not useful for everyone.
