### PR TITLE
Make Get interface consistent with other querying interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ rebecca.SetupDriver(pg.NewDriver("postgres://user:pass@host:port/database?sslmod
 
 ```go
 var p Person
-if err := rebecca.Get(ID, &p); err != nil {
+if err := rebecca.Get(&p, ID); err != nil {
         // handle error here
 }
 
@@ -79,7 +79,7 @@ if err := rebecca.Save(p); err != nil {
 
 // updates the record
 p := &Person{}
-if err := rebecca.Get(ID, p); err != nil {
+if err := rebecca.Get(p, ID); err != nil {
         // handle error here
 }
 

--- a/driver/pg/pg_test.go
+++ b/driver/pg/pg_test.go
@@ -47,7 +47,7 @@ func TestSaveCreates(t *testing.T) {
 	}
 
 	actual := &Person{}
-	if err := rebecca.Get(expected.ID, actual); err != nil {
+	if err := rebecca.Get(actual, expected.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,7 +65,7 @@ func TestSaveUpdates(t *testing.T) {
 	}
 
 	expected := &Person{}
-	if err := rebecca.Get(p.ID, expected); err != nil {
+	if err := rebecca.Get(expected, p.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,7 +75,7 @@ func TestSaveUpdates(t *testing.T) {
 	}
 
 	actual := &Person{}
-	if err := rebecca.Get(p.ID, actual); err != nil {
+	if err := rebecca.Get(actual, p.ID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -39,7 +39,7 @@ func ExampleGet() {
 	}
 
 	person := &Person{}
-	if err := rebecca.Get(25, person); err != nil {
+	if err := rebecca.Get(person, 25); err != nil {
 		panic(err)
 	}
 	// At this point person contains record with primary key equal to 25.
@@ -53,7 +53,7 @@ func ExampleRemove() {
 
 	// First lets find person with primary key = 25
 	person := &Person{}
-	if err := rebecca.Get(25, person); err != nil {
+	if err := rebecca.Get(person, 25); err != nil {
 		panic(err)
 	}
 

--- a/rebecca.go
+++ b/rebecca.go
@@ -30,7 +30,7 @@
 //
 //    // Get record by its primary key
 //    p = &Person{}
-//    if err := rebecca.Get(25, p); err != nil {
+//    if err := rebecca.Get(p, 25); err != nil {
 //            // handle error here
 //    }
 //    fmt.Print(p)
@@ -50,7 +50,7 @@ func SetupDriver(d driver.Driver) {
 }
 
 // Get is for fetching one record
-func Get(ID interface{}, record interface{}) error {
+func Get(record interface{}, ID interface{}) error {
 	return get(nil, ID, record)
 }
 

--- a/rebecca_test.go
+++ b/rebecca_test.go
@@ -27,7 +27,7 @@ func TestSaveCreates(t *testing.T) {
 	}
 
 	actual := &Person{}
-	if err := Get(expected.ID, actual); err != nil {
+	if err := Get(actual, expected.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -53,7 +53,7 @@ func TestSaveUpdates(t *testing.T) {
 	}
 
 	expected := &Person{}
-	if err := Get(p.ID, expected); err != nil {
+	if err := Get(expected, p.ID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -63,7 +63,7 @@ func TestSaveUpdates(t *testing.T) {
 	}
 
 	actual := &Person{}
-	if err := Get(p.ID, actual); err != nil {
+	if err := Get(actual, p.ID); err != nil {
 		t.Fatal(err)
 	}
 

--- a/transaction.go
+++ b/transaction.go
@@ -65,8 +65,8 @@ func (tx *Transaction) Commit() error {
 }
 
 // Get is for fetching one record
-func (tx *Transaction) Get(ID interface{}, record interface{}) error {
-	return get(tx.tx, ID, record)
+func (tx *Transaction) Get(record interface{}, ID interface{}) error {
+	return get(tx.tx, record, ID)
 }
 
 // Save is for saving one record (either creating or updating)

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -34,7 +34,7 @@ func ExampleBegin() {
 	// methods on `tx`:
 	// - tx.All(records)
 	// - tx.First(record, where, args...)
-	// - tx.Get(ID, record)
+	// - tx.Get(record, ID)
 	// - tx.Remove(record)
 	// - tx.Save(record)
 	// - tx.Where(records, where, args...)


### PR DESCRIPTION
Before this PR:
- `Get(ID, person)`
- `Where(people, query, args...)`
- `First(person, query, args...)`
- `All(people)`

So all querying functions except `Get`, have their destination first and querying details after (except `All` it does not have any details). This makes `Get` kind of weird

This PR makes it consistent:
- `Get(person, ID)`
- `Where(people, query, args...)`
- `First(person, query, args...)`
- `All(people)`

I believe this might cause less confusion and mistakes.
